### PR TITLE
prevent symbolized keys in location:

### DIFF
--- a/lib/jekyll-contentful-data-import/mappers/base.rb
+++ b/lib/jekyll-contentful-data-import/mappers/base.rb
@@ -71,7 +71,7 @@ module Jekyll
         end
 
         def map_location(location)
-          location.properties
+          {'lat' => location.lat, 'lon' => location.lon}
         end
 
         def map_link(link)


### PR DESCRIPTION
tests pass in the form they have been written, but the produced yml includes symbolized keys which I wasn't able to read with liquid tags

i.e.:

```
  location:
    :lat: 37.77493
    :lon: -122.41942
```

new output will be:

```
  location:
    lat: 37.77493
    lon: -122.41942
```
