### PR TITLE
Add option to export files by content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ contentful:
           limit: 100
         all_entries: true           # Optional - Defaults to false, only grabbing the amount set on CDA Query
         all_entries_page_size: 1000 # Optional - Defaults to 1000, maximum amount of entries per CDA Request for all_entries
+        multiple_files: true        # Optional - Defaults to false, split up data by content type
         content_types:              # Optional
           cat: MyCoolMapper
         client_options:             # Optional
@@ -64,6 +65,7 @@ access_token          | Contentful Delivery API access token
 cda_query             | Hash describing query configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info (look for filter options there). Note that by default only 100 entries will be fetched, this can be configured to up to 1000 entries using the `limit` option.
 all_entries           | Boolean, if true will run multiple queries to the API until it fetches all entries for the space
 all_entries_page_size | Integer, the amount of maximum entries per CDA Request when fetching :all_entries
+multiple_files:       | Boolean, if true will split up the data into one file per content type
 content_types         | Hash describing the mapping applied to entries of the imported content types
 client_options        | Hash describing Contentful::Client configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info.
 base_path             | String with path to your Jekyll Application, defaults to current directory. Path is relative to your current location.

--- a/lib/jekyll-contentful-data-import/data_exporter.rb
+++ b/lib/jekyll-contentful-data-import/data_exporter.rb
@@ -17,9 +17,24 @@ module Jekyll
 
       def run
         setup_directory
+        puts config
+        export_fn = config['multiple_files'] ? export_by_content_type : export
+        export_fn
+      end
 
+      def export
+        grouped_entries = ::Jekyll::Contentful::Serializer.new(entries, config).serialize
         File.open(destination_file, 'w') do |file|
-          file.write(::Jekyll::Contentful::Serializer.new(entries, config).to_yaml)
+          file.write(YAML.dump(grouped_entries))
+        end
+      end
+
+      def export_by_content_type
+        grouped_entries = ::Jekyll::Contentful::Serializer.new(entries, config).serialize
+        grouped_entries.each do |content_type, entry_list|
+          File.open(destination_file(content_type), 'w') do |file|
+            file.write(YAML.dump(entry_list))
+          end
         end
       end
 
@@ -34,8 +49,8 @@ module Jekyll
         File.join(base_directory, DATA_FOLDER, CONTENTFUL_FOLDER, SPACES_FOLDER)
       end
 
-      def destination_file
-        File.join(destination_directory, "#{name}.yaml")
+      def destination_file(file_name = name)
+        File.join(destination_directory, "#{file_name}.yaml")
       end
 
       def setup_directory

--- a/spec/jekyll-contentful/data_exporter_spec.rb
+++ b/spec/jekyll-contentful/data_exporter_spec.rb
@@ -75,7 +75,7 @@ describe Jekyll::Contentful::DataExporter do
 
       it 'serializes entries onto data file' do
         allow(File).to receive(:open).and_yield(StringIO.new)
-        expect_any_instance_of(::Jekyll::Contentful::Serializer).to receive(:to_yaml)
+        expect(YAML).to receive(:dump)
 
         subject.run
       end

--- a/spec/jekyll-contentful/serializer_spec.rb
+++ b/spec/jekyll-contentful/serializer_spec.rb
@@ -63,11 +63,5 @@ describe Jekyll::Contentful::Serializer do
       end
     end
 
-    it '#to_yaml' do
-      allow(subject).to receive(:serialize).and_return({'a' => 123})
-
-      expected = "---\na: 123\n"
-      expect(subject.to_yaml).to eq(expected)
-    end
   end
 end


### PR DESCRIPTION
Hi,

For our Jekyll site at @sumup we were looking for a way to import and include content from Contentful. One requirement is that we need to be able to easily create one page per entry while using different layouts based on content type. We found this handy little Jekyll plugin: [avillafiorita/jekyll-datapage_gen](https://github.com/avillafiorita/jekyll-datapage_gen).

However, it expects each data type (i.e. a blog posts, products, job ads) to be included in its own YAML/JSON file. We thought this might in general be a nice option for storing our content from Contentful inside the Jekyll project.

Looking at your nice plugin we couldn't find a way to split up the Contentful data. I implemented the feature and would love to see it get merged. This is close to all the Ruby I've written in my life and I haven't fully updated the tests, yet. What do you think?

Can you actually help me mock the collection of entries with different content types? Never done any of this before and I bet you'd be able to give me a quick lift?

*TODO*
- [ ] Incorporate feedback.
- [ ] Group files from one space within a folder.
- [ ] Update tests to check for one vs. multiple export files.