### PR TITLE
Enable custom Jekyll configuration file

### DIFF
--- a/lib/jekyll/commands/contentful.rb
+++ b/lib/jekyll/commands/contentful.rb
@@ -11,7 +11,8 @@ module Jekyll
           options.each {|opt| c.option(*opt) }
 
           c.action do |args, options|
-            contentful_config = Jekyll.configuration['contentful']
+            jekyll_options = configuration_from_options(options)
+            contentful_config = jekyll_options['contentful']
             process args, options, contentful_config
           end
         end
@@ -20,6 +21,7 @@ module Jekyll
       def self.options
         [
           ['rebuild', '-r', '--rebuild', 'Rebuild Jekyll Site after fetching data'],
+          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, "Custom configuration file"]
         ]
       end
 


### PR DESCRIPTION
I would like to use a custom Jekyll configuration, specifiable via the standard `--config` flag also used by the `build` command. The `build` command achieves this by generating the options for Jekyll using the [`configuration_from_options` method of the `Command` class](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/commands/build.rb#L27).

I've adopted this same behavior for this plugin. I'm not sure how to test this, so I'd be grateful for testing hints.