### PR TITLE
Allow destination directory override

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ contentful:
         client_options:             # Optional
           api_url: 'preview.contentful.com' # Defaults to 'api.contentful.com' which is Production
         base_path: app_path         # Optional - Defaults to Current directory
-        destination: destination_in_data # Optional - Defaults to _data/contentful/spaces/{space}
+        destination: destination_in_data # Optional - Defaults to _data/contentful/spaces/{_data folder identifier}
 ```
 
 Parameter             | Description

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ contentful:
         client_options:             # Optional
           api_url: 'preview.contentful.com' # Defaults to 'api.contentful.com' which is Production
         base_path: app_path         # Optional - Defaults to Current directory
-
+        destination: destination_in_data # Optional - Defaults to _data/contentful/spaces/{space}
 ```
 
 Parameter             | Description
@@ -67,6 +67,7 @@ all_entries_page_size | Integer, the amount of maximum entries per CDA Request w
 content_types         | Hash describing the mapping applied to entries of the imported content types
 client_options        | Hash describing Contentful::Client configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info.
 base_path             | String with path to your Jekyll Application, defaults to current directory. Path is relative to your current location.
+destination           | String with path within _data under which to store the output yaml file. Defaults to contentful/spaces/{_data folder identifier}
 
 You can add multiple spaces to your configuration
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ contentful:
         client_options:             # Optional
           api_url: 'preview.contentful.com' # Defaults to 'api.contentful.com' which is Production
         base_path: app_path         # Optional - Defaults to Current directory
-        destination: destination_in_data # Optional - Defaults to _data/contentful/spaces/{_data folder identifier}
+        destination: destination_in_data # Optional - Defaults to _data/contentful/spaces
 ```
 
 Parameter             | Description
@@ -67,7 +67,7 @@ all_entries_page_size | Integer, the amount of maximum entries per CDA Request w
 content_types         | Hash describing the mapping applied to entries of the imported content types
 client_options        | Hash describing Contentful::Client configuration. See [contentful.rb](https://github.com/contentful/contentful.rb) for more info.
 base_path             | String with path to your Jekyll Application, defaults to current directory. Path is relative to your current location.
-destination           | String with path within _data under which to store the output yaml file. Defaults to contentful/spaces/{_data folder identifier}
+destination           | String with path within _data under which to store the output yaml file. Defaults to contentful/spaces
 
 You can add multiple spaces to your configuration
 

--- a/lib/jekyll-contentful-data-import/data_exporter.rb
+++ b/lib/jekyll-contentful-data-import/data_exporter.rb
@@ -31,7 +31,10 @@ module Jekyll
       end
 
       def destination_directory
-        File.join(base_directory, DATA_FOLDER, CONTENTFUL_FOLDER, SPACES_FOLDER)
+        destination_dir = File.join(base_directory, DATA_FOLDER, CONTENTFUL_FOLDER, SPACES_FOLDER)
+        destination_dir = File.join(base_directory, DATA_FOLDER, config['dest']) if config.key?('dest')
+
+        destination_dir
       end
 
       def destination_file

--- a/lib/jekyll-contentful-data-import/data_exporter.rb
+++ b/lib/jekyll-contentful-data-import/data_exporter.rb
@@ -32,7 +32,7 @@ module Jekyll
 
       def destination_directory
         destination_dir = File.join(base_directory, DATA_FOLDER, CONTENTFUL_FOLDER, SPACES_FOLDER)
-        destination_dir = File.join(base_directory, DATA_FOLDER, config['dest']) if config.key?('dest')
+        destination_dir = File.join(base_directory, DATA_FOLDER, config['destination']) if config.key?('destination')
 
         destination_dir
       end

--- a/spec/jekyll-contentful/data_exporter_spec.rb
+++ b/spec/jekyll-contentful/data_exporter_spec.rb
@@ -24,9 +24,9 @@ describe Jekyll::Contentful::DataExporter do
       end
 
       it 'overriden directory' do
-        subject = described_class.new('foo', [], {'base_path' => 'foo_dir', 'dest' => 'bar_dir'})
+        subject = described_class.new('foo', [], {'base_path' => 'foo_dir'})
 
-        expected = File.join(Dir.pwd, 'foo_dir', '_data', 'bar_dir')
+        expected = File.join(Dir.pwd, 'foo_dir', '_data', 'contentful', 'spaces')
         expect(subject.destination_directory).to eq(expected)
       end
     end
@@ -41,6 +41,13 @@ describe Jekyll::Contentful::DataExporter do
         subject = described_class.new('foo', [], {'base_path' => 'foo_dir'})
 
         expected = File.join(Dir.pwd, 'foo_dir', '_data', 'contentful', 'spaces', 'foo.yaml')
+        expect(subject.destination_file).to eq(expected)
+      end
+
+      it 'overridden destination' do
+        subject = described_class.new('foo', [], {'base_path' => 'foo_dir', 'destination' => 'bar_path'})
+
+        expected = File.join(Dir.pwd, 'foo_dir', '_data', 'bar_path', 'foo.yaml')
         expect(subject.destination_file).to eq(expected)
       end
     end

--- a/spec/jekyll-contentful/data_exporter_spec.rb
+++ b/spec/jekyll-contentful/data_exporter_spec.rb
@@ -24,9 +24,9 @@ describe Jekyll::Contentful::DataExporter do
       end
 
       it 'overriden directory' do
-        subject = described_class.new('foo', [], {'base_path' => 'foo_dir'})
+        subject = described_class.new('foo', [], {'base_path' => 'foo_dir', 'dest' => 'bar_dir'})
 
-        expected = File.join(Dir.pwd, 'foo_dir', '_data', 'contentful', 'spaces')
+        expected = File.join(Dir.pwd, 'foo_dir', '_data', 'bar_dir')
         expect(subject.destination_directory).to eq(expected)
       end
     end


### PR DESCRIPTION
Since we are already able to override the `base_path` inside `_config.yml`, why not also allow for a destination directory override. This PR allows you to set the `dest` property inside a space configuration, which is a sub-path under `base_path/_data/`.

For example, if you would like to store the your imported Contentful data from a space called 'foo' directly inside `_data`, set `dest: ""` inside `_config.yml`:

```yml
spaces:
  - foo:
      space: "cfexampleapi"
      access_token: "b4c0n73n7fu1"
      dest: ""
```