### PR TITLE
Support common Jekyll build options

### DIFF
--- a/lib/jekyll/commands/contentful.rb
+++ b/lib/jekyll/commands/contentful.rb
@@ -11,7 +11,8 @@ module Jekyll
           options.each {|opt| c.option(*opt) }
 
           c.action do |args, options|
-            contentful_config = Jekyll.configuration['contentful']
+            jekyll_options = configuration_from_options(options)
+            contentful_config = jekyll_options['contentful']
             process args, options, contentful_config
           end
         end
@@ -20,6 +21,7 @@ module Jekyll
       def self.options
         [
           ['rebuild', '-r', '--rebuild', 'Rebuild Jekyll Site after fetching data'],
+          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, "Custom configuration file"]
         ]
       end
 

--- a/lib/jekyll/commands/contentful.rb
+++ b/lib/jekyll/commands/contentful.rb
@@ -10,6 +10,8 @@ module Jekyll
 
           options.each {|opt| c.option(*opt) }
 
+          add_build_options(c)
+
           c.action do |args, options|
             jekyll_options = configuration_from_options(options)
             contentful_config = jekyll_options['contentful']
@@ -21,7 +23,6 @@ module Jekyll
       def self.options
         [
           ['rebuild', '-r', '--rebuild', 'Rebuild Jekyll Site after fetching data'],
-          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, "Custom configuration file"]
         ]
       end
 


### PR DESCRIPTION
This is an update of PR #26. I've done some more research and still come to the conclusion that this is a useful and necessary addition to the plugin. Maybe I'm totally wrong about some details of how writing a command works. If so, I'd be thankful for some explanations. In any case, what I'm trying to achieve does currently not work.

Here's my last comment on #26 explaining why:

Hi again @dlitvakb,

You're right, `Command#configuration_from_options` is just a wrapper for `Jekyll#configuration`. However, the `--config` CLI flag does not work out of the box. Here's what I get when I try to pass it 
on the current master branch of the plugin:

```
~/Development/static-marketing feature/MW-249-integrate-contentful
❯ bundle exec jekyll contentful --config _configs/de-DE.yml
jekyll 3.3.0 | Error:  Whoops, we can't understand your command.
jekyll 3.3.0 | Error:  invalid option: --config
jekyll 3.3.0 | Error:  Run your command again with the --help switch to see available options.
```

Doing what Jekyll suggests gives you

```
~/Development/static-marketing feature/MW-249-integrate-contentful
❯ bundle exec jekyll contentful --help
jekyll contentful -- Imports data from Contentful

Usage:

  jekyll contentful [OPTIONS]

Options:
        -r, --rebuild      Rebuild Jekyll Site after fetching data
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs
        -s, --source [DIR]  Source directory (defaults to ./)
        -d, --destination [DIR]  Destination directory (defaults to ./_site)
            --safe         Safe mode (defaults to false)
        -p, --plugins PLUGINS_DIR1[,PLUGINS_DIR2[,...]]  Plugins directory (defaults to ./_plugins)
            --layouts DIR  Layouts directory (defaults to ./_layouts)
            --profile      Generate a Liquid rendering profile
        -h, --help         Show this message
        -v, --version      Print the name and version
        -t, --trace        Show the full backtrace when an error occurs
```

As this shows, `--config` is not a default flag available to all commands. The `Command` class does have a method called [`add_build_options`](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/command.rb#L48-L68), which adds build related options to a Jekyll command passed in as argument. This I did not know before adding the `--config` flag support and opening this PR. But it got me curious and I started to consider other scenarios.

If you try to use the Contentful plugin with the `--rebuild` flag and pass some of the standard `jekyll build` options, it does not work, because the Contentful command does not support these flags:

```
~/Development/static-marketing feature/MW-249-integrate-contentful
❯ bundle exec jekyll contentful --rebuild --watch
jekyll 3.3.0 | Error:  Whoops, we can't understand your command.
jekyll 3.3.0 | Error:  invalid option: --watch
jekyll 3.3.0 | Error:  Run your command again with the --help switch to see available options.
```

This makes me think we really should use `Command#add_build_options` on the Contentful command. Otherwise the `--rebuild` flag won't work whenever people need to also pass other build related options to Jekyll, one of them being the custom config file support this PR tries to address.

Yet, even if you allow for all the build options, you still need to pass the CLI options hash on to `Jekyll#configuration` or `Command#configuration_from_options`. Otherwise, Jekyll will use default configuration values and whatever it finds in `_config.yml`. It will not look for a custom configuration, even if the `--config` flag is used. This can be seen here: https://github.com/jekyll/jekyll/blob/master/lib/jekyll.rb#L93-L113

As a result, if I don't use the standard `_config.yml` file, but something else, for example `./config/my_custom_config.yml`, the Contentful plugin won't [find its configuration](https://github.com/contentful/jekyll-contentful-data-import/blob/master/lib/jekyll/commands/contentful.rb#L14). `Jekyll.configuration['contentful']` will be `nil`. And you will get this error:
```
❯ bundle exec jekyll contentful --config _configs/de-DE.yml
Configuration file: none
Starting Contentful import
jekyll 3.3.0 | Error:  undefined method `[]' for nil:NilClass
```

Summarizing, I suggest the following:

1. Use `Command#add_build_options` to enable any of the build related CLI flags for Jekyll. This will allow passing custom build options when using the Contentful plugins when using the `--rebuild` flag.
2. Pass the options hash to `Jekyll#configuration` or `Command#configuration_from_options` before trying to retrieve the Contentful options in `contentful.rb`. Otherwise you cannot use configuration files other than `_config.yml`.

I'll update my PR and leave some more comments in the code. What do you think?

PS: sorry for the lengthy comment. Just a lot of stuff to consider.