### PR TITLE
Safeguard against unpublished assets

### DIFF
--- a/lib/jekyll-contentful-data-import/mappers/base.rb
+++ b/lib/jekyll-contentful-data-import/mappers/base.rb
@@ -71,7 +71,8 @@ module Jekyll
         end
 
         def map_asset(asset)
-          {'title' => asset.title, 'url' => asset.file.url}
+          url = asset.file.nil? ? nil : asset.file.url
+          {'title' => asset.title, 'url' => url}
         end
 
         def map_entry(child)


### PR DESCRIPTION
When trying to use the plugin with the preview API, it failed, seemingly because some assets were not published, yet. In such cases the `asset.file` was `nil`, causing `map_asset` to fail. This PR adds some safe guarding against that. I'm not a ruby dev, so please let me know, if there is a nicer or more standard way to achieve that.

Thanks