### PR TITLE
Expose revision in system data

### DIFF
--- a/lib/jekyll-contentful-data-import/mappers/base.rb
+++ b/lib/jekyll-contentful-data-import/mappers/base.rb
@@ -33,7 +33,8 @@ module Jekyll
             'id' => entry.sys.fetch(:id, nil),
             'created_at' => entry.sys.fetch(:created_at, nil),
             'updated_at' => entry.sys.fetch(:updated_at, nil),
-            'content_type_id' => content_type.nil? ? nil : content_type.id
+            'content_type_id' => content_type.nil? ? nil : content_type.id,
+            'revision' => entry.sys.fetch(:revision, nil)
           }
         end
 

--- a/spec/jekyll-contentful/mappers/base_spec.rb
+++ b/spec/jekyll-contentful/mappers/base_spec.rb
@@ -83,7 +83,8 @@ describe Jekyll::Contentful::Mappers::Base do
             'id' => 'foo',
             'created_at' => nil,
             'updated_at' => nil,
-            'content_type_id' => 'content_type'
+            'content_type_id' => 'content_type',
+            'revision' => nil
           }
         }
         expect(subject.map).to eq expected
@@ -109,7 +110,8 @@ describe Jekyll::Contentful::Mappers::Base do
             'id' => 'foo',
             'created_at' => nil,
             'updated_at' => nil,
-            'content_type_id' => 'content_type'
+            'content_type_id' => 'content_type',
+            'revision' => nil
           },
           'asset' => {
             'sys' => {
@@ -133,7 +135,8 @@ describe Jekyll::Contentful::Mappers::Base do
               'id' => 'baz',
               'created_at' => nil,
               'updated_at' => nil,
-              'content_type_id' => 'content_type'
+              'content_type_id' => 'content_type',
+              'revision' => nil
             },
           },
           'array' => [
@@ -164,7 +167,8 @@ describe Jekyll::Contentful::Mappers::Base do
             'id' => 'foo',
             'created_at' => nil,
             'updated_at' => nil,
-            'content_type_id' => 'content_type'
+            'content_type_id' => 'content_type',
+            'revision' => nil
           },
           'foo' => {
             'en-US' => 'bar',
@@ -201,7 +205,8 @@ describe Jekyll::Contentful::Mappers::Base do
             'id' => 'foo',
             'created_at' => nil,
             'updated_at' => nil,
-            'content_type_id' => 'content_type'
+            'content_type_id' => 'content_type',
+            'revision' => nil
           },
           'asset' => {
             "en-US" => {

--- a/spec/jekyll-contentful/serializer_spec.rb
+++ b/spec/jekyll-contentful/serializer_spec.rb
@@ -30,7 +30,8 @@ describe Jekyll::Contentful::Serializer do
                 'id' => 'foo',
                 'created_at' => nil,
                 'updated_at' => nil,
-                'content_type_id' => 'content_type'
+                'content_type_id' => 'content_type',
+                'revision' => nil
               }
             }
           ]
@@ -48,7 +49,8 @@ describe Jekyll::Contentful::Serializer do
                 'id' => 'foo',
                 'created_at' => nil,
                 'updated_at' => nil,
-                'content_type_id' => 'content_type'
+                'content_type_id' => 'content_type',
+                'revision' => nil
               },
               'foobar' => 'bar'
             }
@@ -73,14 +75,16 @@ describe Jekyll::Contentful::Serializer do
                 'id' => 'foo',
                 'created_at' => nil,
                 'updated_at' => nil,
-                'content_type_id' => 'content_type'
+                'content_type_id' => 'content_type',
+                'revision' => nil
               },
               'foobar' => {
                 'sys' => {
                   'id' => 'foobar',
                   'created_at' => nil,
                   'updated_at' => nil,
-                  'content_type_id' => 'content_type'
+                  'content_type_id' => 'content_type',
+                  'revision' => nil
                 },
                 'baz' => 1
               }
@@ -103,7 +107,8 @@ describe Jekyll::Contentful::Serializer do
                 'id' => 'foo',
                 'created_at' => nil,
                 'updated_at' => nil,
-                'content_type_id' => 'content_type'
+                'content_type_id' => 'content_type',
+                'revision' => nil
               },
               'foobar' => 'bar'
             },
@@ -112,7 +117,8 @@ describe Jekyll::Contentful::Serializer do
                 'id' => 'bar',
                 'created_at' => nil,
                 'updated_at' => nil,
-                'content_type_id' => 'content_type'
+                'content_type_id' => 'content_type',
+                'revision' => nil
               },
               'foobar' => 'baz'
             }


### PR DESCRIPTION
I need the ability to check if an entry is in draft e.g. `revision` is 0 and to display the revision number.

I noticed the API (and the contentful.rb gem) exposed it so wanted to include it in the data import to Jekyll.