### PR TITLE
Reading preview API URL from environment variables

### DIFF
--- a/lib/jekyll-contentful-data-import/importer.rb
+++ b/lib/jekyll-contentful-data-import/importer.rb
@@ -112,7 +112,7 @@ module Jekyll
 
       def client_options(options)
         options = options.each_with_object({}) do |(k, v), memo|
-          memo[k.to_sym] = value_for(v)
+          memo[k.to_sym] = value_for(options, k)
           memo
         end
 

--- a/lib/jekyll-contentful-data-import/importer.rb
+++ b/lib/jekyll-contentful-data-import/importer.rb
@@ -112,7 +112,7 @@ module Jekyll
 
       def client_options(options)
         options = options.each_with_object({}) do |(k, v), memo|
-          memo[k.to_sym] = v
+          memo[k.to_sym] = value_for(v)
           memo
         end
 


### PR DESCRIPTION
Simple tweak to read the preview API URL from environment variables as we were not able to read the value specified for client options > api url.

```
client_options:
          api_url: ENV_CONTENTFUL_API_URL
```