### PR TITLE
Update rich_text_renderer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+* Updated `rich_text_renderer` gem version.
 
 ## v1.8.1
 ### Fixed

--- a/jekyll-contentful.gemspec
+++ b/jekyll-contentful.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   # Additional dependencies
   s.add_dependency("contentful", '~> 2.1')
-  s.add_dependency("rich_text_renderer", '~> 0.1')
+  s.add_dependency("rich_text_renderer", '~> 0.3')
 
   s.add_development_dependency 'rubygems-tasks', '~> 0.2'
   s.add_development_dependency "guard"


### PR DESCRIPTION
Need to update the rich_text_renderer version number to allow updated RichText features such as Tables to be compiled correctly and not error out.

The updated version from 0.1 to 0.3 is referenced from this version of the rich_text_renderer that allows the Tables in the RichText fields: https://github.com/contentful/rich-text-renderer.rb
